### PR TITLE
Add support for per-request API key override

### DIFF
--- a/src/catsu/client.py
+++ b/src/catsu/client.py
@@ -198,6 +198,7 @@ class Client:
         input: Union[str, List[str]],
         provider: Optional[str] = None,
         input_type: Optional[str] = None,
+        api_key: Optional[str] = None,
         **kwargs: Any,
     ) -> Any:  # -> EmbedResponse
         """Generate embeddings for input text(s).
@@ -208,6 +209,7 @@ class Client:
             provider: Optional provider name (if not in model string)
             input_type: Optional input type hint ("query" or "document")
                        Used by some providers like VoyageAI
+            api_key: Optional API key override for this specific request
             **kwargs: Additional provider-specific parameters
 
         Returns:
@@ -248,6 +250,7 @@ class Client:
             model=model_name,
             inputs=inputs,
             input_type=input_type,
+            api_key=api_key,
             **kwargs,
         )
 
@@ -257,6 +260,7 @@ class Client:
         input: Union[str, List[str]],
         provider: Optional[str] = None,
         input_type: Optional[str] = None,
+        api_key: Optional[str] = None,
         **kwargs: Any,
     ) -> Any:  # -> EmbedResponse
         """Async version of embed().
@@ -268,6 +272,7 @@ class Client:
             input: Single text string or list of text strings
             provider: Optional provider name (if not in model string)
             input_type: Optional input type hint ("query" or "document")
+            api_key: Optional API key override for this specific request
             **kwargs: Additional provider-specific parameters
 
         Returns:
@@ -300,6 +305,7 @@ class Client:
             model=model_name,
             inputs=inputs,
             input_type=input_type,
+            api_key=api_key,
             **kwargs,
         )
 

--- a/src/catsu/providers/base.py
+++ b/src/catsu/providers/base.py
@@ -171,18 +171,43 @@ class BaseProvider(ABC):
                     parameter=f"inputs[{i}]",
                 )
 
-    def _validate_api_key(self) -> None:
+    def _validate_api_key(self, api_key: Optional[str] = None) -> None:
         """Validate that API key is present.
+
+        Args:
+            api_key: Optional override API key (uses self.api_key if not provided)
 
         Raises:
             AuthenticationError: If API key is missing
 
         """
-        if not self.api_key:
+        effective_key = api_key if api_key is not None else self.api_key
+        if not effective_key:
             raise AuthenticationError(
                 f"API key is required for {self.__class__.__name__}. "
                 f"Set it via the Client or environment variable."
             )
+
+    def _get_effective_api_key(self, api_key: Optional[str] = None) -> str:
+        """Get the effective API key, validating it exists.
+
+        Args:
+            api_key: Optional override API key (uses self.api_key if not provided)
+
+        Returns:
+            The effective API key to use
+
+        Raises:
+            AuthenticationError: If no API key is available
+
+        """
+        effective_key = api_key if api_key is not None else self.api_key
+        if not effective_key:
+            raise AuthenticationError(
+                f"API key is required for {self.__class__.__name__}. "
+                f"Set it via the Client or environment variable."
+            )
+        return effective_key
 
     def _log(self, message: str) -> None:
         """Log message if verbose mode is enabled.

--- a/src/catsu/providers/cohere.py
+++ b/src/catsu/providers/cohere.py
@@ -130,16 +130,19 @@ class CohereProvider(BaseProvider):
                 provider=self.PROVIDER_NAME,
             ) from e
 
-    def _get_headers(self) -> Dict[str, str]:
+    def _get_headers(self, api_key: Optional[str] = None) -> Dict[str, str]:
         """Get HTTP headers for API requests.
+
+        Args:
+            api_key: Optional override API key (uses self.api_key if not provided)
 
         Returns:
             Dictionary of headers including authorization
 
         """
-        self._validate_api_key()
+        effective_key = self._get_effective_api_key(api_key)
         return {
-            "Authorization": f"Bearer {self.api_key}",
+            "Authorization": f"Bearer {effective_key}",
             "Content-Type": "application/json",
         }
 
@@ -386,6 +389,7 @@ class CohereProvider(BaseProvider):
         inputs: List[str],
         input_type: Optional[str] = None,
         truncate: Optional[str] = None,
+        api_key: Optional[str] = None,
         **kwargs: Any,
     ) -> EmbedResponse:
         """Generate embeddings using Cohere API (synchronous).
@@ -395,6 +399,7 @@ class CohereProvider(BaseProvider):
             inputs: List of input texts
             input_type: Input type ("search_document", "search_query", "classification", "clustering")
             truncate: Truncation option ("NONE", "START", "END")
+            api_key: Optional API key override for this request
             **kwargs: Additional API parameters
 
         Returns:
@@ -428,7 +433,7 @@ class CohereProvider(BaseProvider):
         payload = self._build_request_payload(
             model, inputs, input_type, truncate, **kwargs
         )
-        headers = self._get_headers()
+        headers = self._get_headers(api_key)
 
         # Make request with retry logic
         start_time = time.time()
@@ -453,6 +458,7 @@ class CohereProvider(BaseProvider):
         inputs: List[str],
         input_type: Optional[str] = None,
         truncate: Optional[str] = None,
+        api_key: Optional[str] = None,
         **kwargs: Any,
     ) -> EmbedResponse:
         """Generate embeddings using Cohere API (asynchronous).
@@ -462,6 +468,7 @@ class CohereProvider(BaseProvider):
             inputs: List of input texts
             input_type: Input type ("search_document", "search_query", "classification", "clustering")
             truncate: Truncation option ("NONE", "START", "END")
+            api_key: Optional API key override for this request
             **kwargs: Additional API parameters
 
         Returns:
@@ -487,7 +494,7 @@ class CohereProvider(BaseProvider):
         payload = self._build_request_payload(
             model, inputs, input_type, truncate, **kwargs
         )
-        headers = self._get_headers()
+        headers = self._get_headers(api_key)
 
         # Make async request with retry logic
         start_time = time.time()

--- a/src/catsu/providers/gemini.py
+++ b/src/catsu/providers/gemini.py
@@ -130,18 +130,20 @@ class GeminiProvider(BaseProvider):
                 provider=self.PROVIDER_NAME,
             ) from e
 
-    def _get_headers(self) -> Dict[str, str]:
+    def _get_headers(self, api_key: Optional[str] = None) -> Dict[str, str]:
         """Get HTTP headers for API requests.
+
+        Args:
+            api_key: Optional override API key (uses self.api_key if not provided)
 
         Returns:
             Dictionary of headers including API key
 
         """
-        self._validate_api_key()
-        assert self.api_key is not None
+        effective_key = self._get_effective_api_key(api_key)
         return {
             "Content-Type": "application/json",
-            "x-goog-api-key": self.api_key,
+            "x-goog-api-key": effective_key,
         }
 
     def _build_request_payload(
@@ -380,6 +382,7 @@ class GeminiProvider(BaseProvider):
         input_type: Optional[str] = None,
         task_type: Optional[str] = None,
         output_dimensionality: Optional[int] = None,
+        api_key: Optional[str] = None,
         **kwargs: Any,
     ) -> EmbedResponse:
         """Generate embeddings using Gemini API (synchronous).
@@ -390,6 +393,7 @@ class GeminiProvider(BaseProvider):
             input_type: Input type ("query" or "document")
             task_type: Gemini task type (e.g., "RETRIEVAL_QUERY", "RETRIEVAL_DOCUMENT")
             output_dimensionality: Output dimensions (128-3072, recommended: 768, 1536, 3072)
+            api_key: Optional API key override for this request
             **kwargs: Additional API parameters
 
         Returns:
@@ -426,7 +430,7 @@ class GeminiProvider(BaseProvider):
             output_dimensionality=output_dimensionality,
             **kwargs,
         )
-        headers = self._get_headers()
+        headers = self._get_headers(api_key)
 
         # Make request with retry logic
         start_time = time.time()
@@ -452,6 +456,7 @@ class GeminiProvider(BaseProvider):
         input_type: Optional[str] = None,
         task_type: Optional[str] = None,
         output_dimensionality: Optional[int] = None,
+        api_key: Optional[str] = None,
         **kwargs: Any,
     ) -> EmbedResponse:
         """Generate embeddings using Gemini API (asynchronous).
@@ -462,6 +467,7 @@ class GeminiProvider(BaseProvider):
             input_type: Input type ("query" or "document")
             task_type: Gemini task type (e.g., "RETRIEVAL_QUERY", "RETRIEVAL_DOCUMENT")
             output_dimensionality: Output dimensions (128-3072)
+            api_key: Optional API key override for this request
             **kwargs: Additional API parameters
 
         Returns:
@@ -490,7 +496,7 @@ class GeminiProvider(BaseProvider):
             output_dimensionality=output_dimensionality,
             **kwargs,
         )
-        headers = self._get_headers()
+        headers = self._get_headers(api_key)
 
         # Make async request with retry logic
         start_time = time.time()

--- a/src/catsu/providers/jinaai.py
+++ b/src/catsu/providers/jinaai.py
@@ -131,16 +131,19 @@ class JinaAIProvider(BaseProvider):
                 provider=self.PROVIDER_NAME,
             ) from e
 
-    def _get_headers(self) -> Dict[str, str]:
+    def _get_headers(self, api_key: Optional[str] = None) -> Dict[str, str]:
         """Get HTTP headers for API requests.
+
+        Args:
+            api_key: Optional override API key (uses self.api_key if not provided)
 
         Returns:
             Dictionary of headers including authorization
 
         """
-        self._validate_api_key()
+        effective_key = self._get_effective_api_key(api_key)
         return {
-            "Authorization": f"Bearer {self.api_key}",
+            "Authorization": f"Bearer {effective_key}",
             "Content-Type": "application/json",
         }
 
@@ -363,6 +366,7 @@ class JinaAIProvider(BaseProvider):
         task: Optional[str] = None,
         dimensions: Optional[int] = None,
         normalized: bool = True,
+        api_key: Optional[str] = None,
         **kwargs: Any,
     ) -> EmbedResponse:
         """Generate embeddings using Jina AI API (synchronous).
@@ -374,6 +378,7 @@ class JinaAIProvider(BaseProvider):
             task: Task type (e.g., "retrieval.query", "retrieval.passage", "text-matching")
             dimensions: Output dimensions (for Matryoshka models)
             normalized: L2 normalize embeddings (default: True)
+            api_key: Optional API key override for this request
             **kwargs: Additional API parameters
 
         Returns:
@@ -412,7 +417,7 @@ class JinaAIProvider(BaseProvider):
             normalized=normalized,
             **kwargs,
         )
-        headers = self._get_headers()
+        headers = self._get_headers(api_key)
 
         # Make request with retry logic
         start_time = time.time()
@@ -439,6 +444,7 @@ class JinaAIProvider(BaseProvider):
         task: Optional[str] = None,
         dimensions: Optional[int] = None,
         normalized: bool = True,
+        api_key: Optional[str] = None,
         **kwargs: Any,
     ) -> EmbedResponse:
         """Generate embeddings using Jina AI API (asynchronous).
@@ -450,6 +456,7 @@ class JinaAIProvider(BaseProvider):
             task: Task type (e.g., "retrieval.query", "retrieval.passage", "text-matching")
             dimensions: Output dimensions (for Matryoshka models)
             normalized: L2 normalize embeddings (default: True)
+            api_key: Optional API key override for this request
             **kwargs: Additional API parameters
 
         Returns:
@@ -480,7 +487,7 @@ class JinaAIProvider(BaseProvider):
             normalized=normalized,
             **kwargs,
         )
-        headers = self._get_headers()
+        headers = self._get_headers(api_key)
 
         # Make async request with retry logic
         start_time = time.time()

--- a/src/catsu/providers/mistral.py
+++ b/src/catsu/providers/mistral.py
@@ -129,16 +129,19 @@ class MistralProvider(BaseProvider):
                 provider=self.PROVIDER_NAME,
             ) from e
 
-    def _get_headers(self) -> Dict[str, str]:
+    def _get_headers(self, api_key: Optional[str] = None) -> Dict[str, str]:
         """Get HTTP headers for API requests.
+
+        Args:
+            api_key: Optional override API key (uses self.api_key if not provided)
 
         Returns:
             Dictionary of headers including authorization
 
         """
-        self._validate_api_key()
+        effective_key = self._get_effective_api_key(api_key)
         return {
-            "Authorization": f"Bearer {self.api_key}",
+            "Authorization": f"Bearer {effective_key}",
             "Content-Type": "application/json",
         }
 
@@ -348,6 +351,7 @@ class MistralProvider(BaseProvider):
         inputs: List[str],
         input_type: Optional[str] = None,
         encoding_format: Optional[str] = None,
+        api_key: Optional[str] = None,
         **kwargs: Any,
     ) -> EmbedResponse:
         """Generate embeddings using Mistral AI API (synchronous).
@@ -357,6 +361,7 @@ class MistralProvider(BaseProvider):
             inputs: List of input texts (up to 512 texts for batch)
             input_type: Input type ("query" or "document")
             encoding_format: Output encoding format (e.g., "float", "int8")
+            api_key: Optional API key override for this request
             **kwargs: Additional API parameters
 
         Returns:
@@ -389,7 +394,7 @@ class MistralProvider(BaseProvider):
         payload = self._build_request_payload(
             model, inputs, encoding_format=encoding_format, **kwargs
         )
-        headers = self._get_headers()
+        headers = self._get_headers(api_key)
 
         # Make request with retry logic
         start_time = time.time()
@@ -414,6 +419,7 @@ class MistralProvider(BaseProvider):
         inputs: List[str],
         input_type: Optional[str] = None,
         encoding_format: Optional[str] = None,
+        api_key: Optional[str] = None,
         **kwargs: Any,
     ) -> EmbedResponse:
         """Generate embeddings using Mistral AI API (asynchronous).
@@ -423,6 +429,7 @@ class MistralProvider(BaseProvider):
             inputs: List of input texts (up to 512 texts for batch)
             input_type: Input type ("query" or "document")
             encoding_format: Output encoding format (e.g., "float", "int8")
+            api_key: Optional API key override for this request
             **kwargs: Additional API parameters
 
         Returns:
@@ -447,7 +454,7 @@ class MistralProvider(BaseProvider):
         payload = self._build_request_payload(
             model, inputs, encoding_format=encoding_format, **kwargs
         )
-        headers = self._get_headers()
+        headers = self._get_headers(api_key)
 
         # Make async request with retry logic
         start_time = time.time()

--- a/src/catsu/providers/openai.py
+++ b/src/catsu/providers/openai.py
@@ -129,16 +129,19 @@ class OpenAIProvider(BaseProvider):
                 provider=self.PROVIDER_NAME,
             ) from e
 
-    def _get_headers(self) -> Dict[str, str]:
+    def _get_headers(self, api_key: Optional[str] = None) -> Dict[str, str]:
         """Get HTTP headers for API requests.
+
+        Args:
+            api_key: Optional override API key (uses self.api_key if not provided)
 
         Returns:
             Dictionary of headers including authorization
 
         """
-        self._validate_api_key()
+        effective_key = self._get_effective_api_key(api_key)
         return {
-            "Authorization": f"Bearer {self.api_key}",
+            "Authorization": f"Bearer {effective_key}",
             "Content-Type": "application/json",
         }
 
@@ -353,6 +356,7 @@ class OpenAIProvider(BaseProvider):
         inputs: List[str],
         input_type: Optional[str] = None,
         dimensions: Optional[int] = None,
+        api_key: Optional[str] = None,
         **kwargs: Any,
     ) -> EmbedResponse:
         """Generate embeddings using OpenAI API (synchronous).
@@ -362,6 +366,7 @@ class OpenAIProvider(BaseProvider):
             inputs: List of input texts
             input_type: Ignored (OpenAI doesn't support input_type)
             dimensions: Optional output dimensions (only for text-embedding-3 models)
+            api_key: Optional API key override for this request
             **kwargs: Additional API parameters
 
         Returns:
@@ -392,7 +397,7 @@ class OpenAIProvider(BaseProvider):
         # Build request
         url = f"{self.API_BASE_URL}/embeddings"
         payload = self._build_request_payload(model, inputs, dimensions, **kwargs)
-        headers = self._get_headers()
+        headers = self._get_headers(api_key)
 
         # Make request with retry logic
         start_time = time.time()
@@ -416,6 +421,7 @@ class OpenAIProvider(BaseProvider):
         inputs: List[str],
         input_type: Optional[str] = None,
         dimensions: Optional[int] = None,
+        api_key: Optional[str] = None,
         **kwargs: Any,
     ) -> EmbedResponse:
         """Generate embeddings using OpenAI API (asynchronous).
@@ -425,6 +431,7 @@ class OpenAIProvider(BaseProvider):
             inputs: List of input texts
             input_type: Ignored (OpenAI doesn't support input_type)
             dimensions: Optional output dimensions (only for text-embedding-3 models)
+            api_key: Optional API key override for this request
             **kwargs: Additional API parameters
 
         Returns:
@@ -447,7 +454,7 @@ class OpenAIProvider(BaseProvider):
         # Build request
         url = f"{self.API_BASE_URL}/embeddings"
         payload = self._build_request_payload(model, inputs, dimensions, **kwargs)
-        headers = self._get_headers()
+        headers = self._get_headers(api_key)
 
         # Make async request with retry logic
         start_time = time.time()

--- a/src/catsu/providers/voyageai.py
+++ b/src/catsu/providers/voyageai.py
@@ -128,16 +128,19 @@ class VoyageAIProvider(BaseProvider):
                 provider=self.PROVIDER_NAME,
             ) from e
 
-    def _get_headers(self) -> Dict[str, str]:
+    def _get_headers(self, api_key: Optional[str] = None) -> Dict[str, str]:
         """Get HTTP headers for API requests.
+
+        Args:
+            api_key: Optional override API key (uses self.api_key if not provided)
 
         Returns:
             Dictionary of headers including authorization
 
         """
-        self._validate_api_key()
+        effective_key = self._get_effective_api_key(api_key)
         return {
-            "Authorization": f"Bearer {self.api_key}",
+            "Authorization": f"Bearer {effective_key}",
             "Content-Type": "application/json",
         }
 
@@ -351,6 +354,7 @@ class VoyageAIProvider(BaseProvider):
         model: str,
         inputs: List[str],
         input_type: Optional[str] = None,
+        api_key: Optional[str] = None,
         **kwargs: Any,
     ) -> EmbedResponse:
         """Generate embeddings using VoyageAI API (synchronous).
@@ -359,6 +363,7 @@ class VoyageAIProvider(BaseProvider):
             model: Model name (e.g., "voyage-3", "voyage-3-lite")
             inputs: List of input texts
             input_type: Input type ("query" or "document")
+            api_key: Optional API key override for this request
             **kwargs: Additional API parameters
 
         Returns:
@@ -390,7 +395,7 @@ class VoyageAIProvider(BaseProvider):
         # Build request
         url = f"{self.API_BASE_URL}/embeddings"
         payload = self._build_request_payload(model, inputs, input_type, **kwargs)
-        headers = self._get_headers()
+        headers = self._get_headers(api_key)
 
         # Make request with retry logic
         start_time = time.time()
@@ -414,6 +419,7 @@ class VoyageAIProvider(BaseProvider):
         model: str,
         inputs: List[str],
         input_type: Optional[str] = None,
+        api_key: Optional[str] = None,
         **kwargs: Any,
     ) -> EmbedResponse:
         """Generate embeddings using VoyageAI API (asynchronous).
@@ -422,6 +428,7 @@ class VoyageAIProvider(BaseProvider):
             model: Model name (e.g., "voyage-3", "voyage-3-lite")
             inputs: List of input texts
             input_type: Input type ("query" or "document")
+            api_key: Optional API key override for this request
             **kwargs: Additional API parameters
 
         Returns:
@@ -445,7 +452,7 @@ class VoyageAIProvider(BaseProvider):
         # Build request
         url = f"{self.API_BASE_URL}/embeddings"
         payload = self._build_request_payload(model, inputs, input_type, **kwargs)
-        headers = self._get_headers()
+        headers = self._get_headers(api_key)
 
         # Make async request with retry logic
         start_time = time.time()


### PR DESCRIPTION
This pull request adds support for per-request API key overrides in the embedding client and all provider classes. This allows users to specify an API key for individual embedding requests, rather than relying solely on the client or environment variable. The changes ensure the API key is properly validated and used in all synchronous and asynchronous embedding methods.

#### API key override support

* Added an `api_key` parameter to the `embed` and `aembed` methods in `src/catsu/client.py`, allowing users to override the API key for individual requests. The parameter is documented and passed through to provider methods. [[1]](diffhunk://#diff-871773a2d2ac486435197e05570dc12f69aeae803733eea642de7543b73f16b7R201) [[2]](diffhunk://#diff-871773a2d2ac486435197e05570dc12f69aeae803733eea642de7543b73f16b7R212) [[3]](diffhunk://#diff-871773a2d2ac486435197e05570dc12f69aeae803733eea642de7543b73f16b7R253) [[4]](diffhunk://#diff-871773a2d2ac486435197e05570dc12f69aeae803733eea642de7543b73f16b7R263) [[5]](diffhunk://#diff-871773a2d2ac486435197e05570dc12f69aeae803733eea642de7543b73f16b7R275) [[6]](diffhunk://#diff-871773a2d2ac486435197e05570dc12f69aeae803733eea642de7543b73f16b7R308)
* Updated provider base class (`src/catsu/providers/base.py`) to support API key overrides, including validation and retrieval of the effective API key. Added `_get_effective_api_key` and updated `_validate_api_key` to accept an override.

#### Provider implementation updates

* Modified all provider classes (`cohere.py`, `gemini.py`, `jinaai.py`, `mistral.py`) to accept and use the `api_key` parameter in their `embed` and `aembed` methods, passing it through to header construction and validation. [[1]](diffhunk://#diff-6b5d18a6e9aa6b365ad593872161b61b747f12c891b8bf292ff1f23f0544e58cR392) [[2]](diffhunk://#diff-6b5d18a6e9aa6b365ad593872161b61b747f12c891b8bf292ff1f23f0544e58cR402) [[3]](diffhunk://#diff-6b5d18a6e9aa6b365ad593872161b61b747f12c891b8bf292ff1f23f0544e58cL431-R436) [[4]](diffhunk://#diff-6b5d18a6e9aa6b365ad593872161b61b747f12c891b8bf292ff1f23f0544e58cR461) [[5]](diffhunk://#diff-6b5d18a6e9aa6b365ad593872161b61b747f12c891b8bf292ff1f23f0544e58cR471) [[6]](diffhunk://#diff-6b5d18a6e9aa6b365ad593872161b61b747f12c891b8bf292ff1f23f0544e58cL490-R497) [[7]](diffhunk://#diff-20cf4965fe9af7311adfa96e23c077d170524d044c18b3a7a42ac2eebc53faddR385) [[8]](diffhunk://#diff-20cf4965fe9af7311adfa96e23c077d170524d044c18b3a7a42ac2eebc53faddR396) [[9]](diffhunk://#diff-20cf4965fe9af7311adfa96e23c077d170524d044c18b3a7a42ac2eebc53faddL429-R433) [[10]](diffhunk://#diff-20cf4965fe9af7311adfa96e23c077d170524d044c18b3a7a42ac2eebc53faddR459) [[11]](diffhunk://#diff-20cf4965fe9af7311adfa96e23c077d170524d044c18b3a7a42ac2eebc53faddR470) [[12]](diffhunk://#diff-20cf4965fe9af7311adfa96e23c077d170524d044c18b3a7a42ac2eebc53faddL493-R499) [[13]](diffhunk://#diff-5ec5581a82aaca9ebfc964b8e34988ce2b39ce93368588b1919fb73f7d5788e3R369) [[14]](diffhunk://#diff-5ec5581a82aaca9ebfc964b8e34988ce2b39ce93368588b1919fb73f7d5788e3R381) [[15]](diffhunk://#diff-5ec5581a82aaca9ebfc964b8e34988ce2b39ce93368588b1919fb73f7d5788e3L415-R420) [[16]](diffhunk://#diff-5ec5581a82aaca9ebfc964b8e34988ce2b39ce93368588b1919fb73f7d5788e3R447) [[17]](diffhunk://#diff-5ec5581a82aaca9ebfc964b8e34988ce2b39ce93368588b1919fb73f7d5788e3R459) [[18]](diffhunk://#diff-5ec5581a82aaca9ebfc964b8e34988ce2b39ce93368588b1919fb73f7d5788e3L483-R490) [[19]](diffhunk://#diff-e2851bb92065163fd47b8de395f1ab1e82afe4bc31c50e940d6ce046908fa916R354) [[20]](diffhunk://#diff-e2851bb92065163fd47b8de395f1ab1e82afe4bc31c50e940d6ce046908fa916R364) [[21]](diffhunk://#diff-e2851bb92065163fd47b8de395f1ab1e82afe4bc31c50e940d6ce046908fa916L392-R397) [[22]](diffhunk://#diff-e2851bb92065163fd47b8de395f1ab1e82afe4bc31c50e940d6ce046908fa916R422)

#### Header construction and validation

* Updated `_get_headers` methods in all providers to accept an optional `api_key` parameter and use the effective API key for authorization or API key headers. [[1]](diffhunk://#diff-6b5d18a6e9aa6b365ad593872161b61b747f12c891b8bf292ff1f23f0544e58cL133-R145) [[2]](diffhunk://#diff-20cf4965fe9af7311adfa96e23c077d170524d044c18b3a7a42ac2eebc53faddL133-R146) [[3]](diffhunk://#diff-5ec5581a82aaca9ebfc964b8e34988ce2b39ce93368588b1919fb73f7d5788e3L134-R146) [[4]](diffhunk://#diff-e2851bb92065163fd47b8de395f1ab1e82afe4bc31c50e940d6ce046908fa916L132-R144)

These changes make the embedding client and providers more flexible and secure by allowing fine-grained control over API key usage for each request.