### PR TITLE
WIP: Add fallback support with new configuration, error handling, and metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ dmypy.json
 
 # Temporary files
 .tmp/
+docs/design/fallback-support.md
+docs/release-posts.md

--- a/src/catsu/__init__.py
+++ b/src/catsu/__init__.py
@@ -8,17 +8,44 @@ rich model metadata.
 from .catalog import ModelCatalog
 from .client import Client
 from .models import EmbedResponse, ModelInfo, TokenizeResponse, Usage
+from .utils.errors import (
+    AuthenticationError,
+    CatsuError,
+    ConfigurationError,
+    FallbackExhaustedError,
+    InvalidInputError,
+    ModelNotFoundError,
+    NetworkError,
+    ProviderError,
+    RateLimitError,
+    TimeoutError,
+    UnsupportedFeatureError,
+)
 
 __version__ = "0.0.2"
 __author__ = "Chonkie, Inc."
 
 __all__ = [
+    # Client and models
     "Client",
     "EmbedResponse",
     "Usage",
     "TokenizeResponse",
     "ModelInfo",
     "ModelCatalog",
+    # Exceptions
+    "CatsuError",
+    "ProviderError",
+    "AuthenticationError",
+    "RateLimitError",
+    "TimeoutError",
+    "NetworkError",
+    "ModelNotFoundError",
+    "InvalidInputError",
+    "UnsupportedFeatureError",
+    "ConfigurationError",
+    "FallbackExhaustedError",
+    # Package metadata
     "__version__",
     "__author__",
 ]

--- a/src/catsu/models.py
+++ b/src/catsu/models.py
@@ -95,6 +95,9 @@ class EmbedResponse(BaseModel):
         latency_ms: Request latency in milliseconds
         input_count: Number of input texts processed
         input_type: Type of input ("query" or "document")
+        requested_model: Original model requested (if fallback was used)
+        fallback_used: Whether a fallback model was used
+        fallback_reason: Reason why fallback was triggered
 
     Example:
         >>> response = EmbedResponse(
@@ -122,6 +125,19 @@ class EmbedResponse(BaseModel):
     input_type: str = Field(
         default="document",
         description='Input type: "query" or "document"',
+    )
+    # Fallback metadata
+    requested_model: Optional[str] = Field(
+        default=None,
+        description="Original model requested (set when fallback was used)",
+    )
+    fallback_used: bool = Field(
+        default=False,
+        description="Whether a fallback model was used",
+    )
+    fallback_reason: Optional[str] = Field(
+        default=None,
+        description="Reason why fallback was triggered (e.g., 'RateLimitError')",
     )
 
     @field_validator("dimensions")
@@ -202,12 +218,15 @@ class EmbedResponse(BaseModel):
 
     def __repr__(self) -> str:
         """Return string representation of EmbedResponse."""
-        return (
+        base = (
             f"EmbedResponse(model='{self.model}', provider='{self.provider}', "
             f"input_count={self.input_count}, dimensions={self.dimensions}, "
             f"tokens={self.usage.tokens}, cost=${self.usage.cost:.6f}, "
-            f"latency={self.latency_ms:.2f}ms)"
+            f"latency={self.latency_ms:.2f}ms"
         )
+        if self.fallback_used:
+            base += f", fallback_used=True, requested_model='{self.requested_model}'"
+        return base + ")"
 
 
 class ModelInfo(BaseModel):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,14 +1,19 @@
 """Tests for Client class."""
 
 import os
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from catsu import Client
-from catsu.models import EmbedResponse
+from catsu.models import EmbedResponse, Usage
 from catsu.utils.errors import (
+    ConfigurationError,
+    FallbackExhaustedError,
     InvalidInputError,
     ModelNotFoundError,
+    NetworkError,
+    RateLimitError,
     UnsupportedFeatureError,
 )
 
@@ -239,3 +244,266 @@ class TestClientContextManager:
         """Test async context manager."""
         async with Client() as client:
             assert client is not None
+
+
+class TestFallbackNormalization:
+    """Tests for fallback normalization."""
+
+    def test_normalize_fallbacks_none(self):
+        """Test normalizing None returns empty list."""
+        client = Client()
+        result = client._normalize_fallbacks(None)
+        assert result == []
+
+    def test_normalize_fallbacks_string(self):
+        """Test normalizing string returns single-item list."""
+        client = Client()
+        result = client._normalize_fallbacks("text-embedding-3-small")
+        assert result == [{"model": "text-embedding-3-small"}]
+
+    def test_normalize_fallbacks_dict(self):
+        """Test normalizing dict returns single-item list."""
+        client = Client()
+        config = {"model": "text-embedding-3-small", "api_key": "test-key"}
+        result = client._normalize_fallbacks(config)
+        assert result == [config]
+
+    def test_normalize_fallbacks_list_of_strings(self):
+        """Test normalizing list of strings."""
+        client = Client()
+        result = client._normalize_fallbacks(["model-a", "model-b"])
+        assert result == [{"model": "model-a"}, {"model": "model-b"}]
+
+    def test_normalize_fallbacks_mixed_list(self):
+        """Test normalizing mixed list of strings and dicts."""
+        client = Client()
+        fallbacks = [
+            "model-a",
+            {"model": "model-b", "api_key": "key-b"},
+        ]
+        result = client._normalize_fallbacks(fallbacks)
+        assert result == [
+            {"model": "model-a"},
+            {"model": "model-b", "api_key": "key-b"},
+        ]
+
+
+class TestFallbackCredentialValidation:
+    """Tests for fallback credential validation."""
+
+    def test_validate_credentials_missing_primary(self, monkeypatch):
+        """Test ConfigurationError raised when primary model API key missing."""
+        # Clear all API keys
+        for key in ["VOYAGE_API_KEY", "OPENAI_API_KEY", "COHERE_API_KEY"]:
+            monkeypatch.delenv(key, raising=False)
+
+        client = Client()
+        with pytest.raises(ConfigurationError) as exc_info:
+            client._validate_fallback_credentials(
+                "voyageai:voyage-3",
+                [{"model": "openai:text-embedding-3-small"}],
+            )
+        assert "VOYAGE_API_KEY" in str(exc_info.value)
+
+    def test_validate_credentials_missing_fallback(self, monkeypatch):
+        """Test ConfigurationError raised when fallback API key missing."""
+        monkeypatch.setenv("VOYAGE_API_KEY", "test-key")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        client = Client()
+        with pytest.raises(ConfigurationError) as exc_info:
+            client._validate_fallback_credentials(
+                "voyageai:voyage-3",
+                [{"model": "openai:text-embedding-3-small"}],
+            )
+        assert "OPENAI_API_KEY" in str(exc_info.value)
+
+    def test_validate_credentials_all_present(self, monkeypatch):
+        """Test no error when all API keys are present."""
+        monkeypatch.setenv("VOYAGE_API_KEY", "key-1")
+        monkeypatch.setenv("OPENAI_API_KEY", "key-2")
+
+        client = Client()
+        # Should not raise
+        client._validate_fallback_credentials(
+            "voyageai:voyage-3",
+            [{"model": "openai:text-embedding-3-small"}],
+        )
+
+
+class TestFallbackDimensionFiltering:
+    """Tests for fallback dimension filtering."""
+
+    def test_can_produce_dimensions_exact_match(self):
+        """Test model with exact matching dimensions is compatible."""
+        client = Client()
+        # embed-english-v3.0 has 1024 dims and doesn't support custom
+        assert client._can_produce_dimensions("cohere", "embed-english-v3.0", 1024)
+
+    def test_can_produce_dimensions_supports_custom(self):
+        """Test model with custom dimension support is compatible."""
+        client = Client()
+        # voyage-3 supports custom dimensions
+        assert client._can_produce_dimensions("voyageai", "voyage-3", 512)
+
+    def test_can_produce_dimensions_mismatch(self):
+        """Test model with mismatched dimensions is not compatible."""
+        client = Client()
+        # text-embedding-ada-002 has 1536 dims and doesn't support custom
+        assert not client._can_produce_dimensions("openai", "text-embedding-ada-002", 1024)
+
+    def test_filter_compatible_fallbacks(self):
+        """Test filtering fallbacks by dimension compatibility."""
+        client = Client()
+        fallbacks = [
+            {"model": "voyageai:voyage-3-lite"},  # Supports custom dims
+            {"model": "openai:text-embedding-ada-002"},  # 1536 fixed
+        ]
+        compatible = client._filter_compatible_fallbacks(1024, fallbacks)
+        # Only voyage-3-lite should be compatible (supports custom dims)
+        assert len(compatible) == 1
+        assert compatible[0]["model"] == "voyageai:voyage-3-lite"
+
+
+class TestFallbackErrorClassification:
+    """Tests for fallback error classification."""
+
+    def test_rate_limit_error_triggers_fallback(self):
+        """Test RateLimitError triggers fallback."""
+        client = Client()
+        error = RateLimitError("Rate limited", provider="test")
+        assert client._is_fallback_error(error)
+
+    def test_network_error_triggers_fallback(self):
+        """Test NetworkError triggers fallback."""
+        client = Client()
+        error = NetworkError("Connection failed", provider="test")
+        assert client._is_fallback_error(error)
+
+    def test_invalid_input_error_does_not_trigger_fallback(self):
+        """Test InvalidInputError does not trigger fallback."""
+        client = Client()
+        error = InvalidInputError("Bad input")
+        assert not client._is_fallback_error(error)
+
+
+class TestFallbackClientConfiguration:
+    """Tests for client-level fallback configuration."""
+
+    def test_client_fallback_defaults(self):
+        """Test client initializes with fallback defaults."""
+        client = Client()
+        assert client.fallbacks is None
+        assert client.allow_unsafe_fallback is False
+        assert client.base_delay == 1.0
+        assert client.max_delay == 10.0
+
+    def test_client_fallback_custom_config(self):
+        """Test client with custom fallback config."""
+        client = Client(
+            fallbacks=["text-embedding-3-small"],
+            allow_unsafe_fallback=True,
+            base_delay=2.0,
+            max_delay=20.0,
+        )
+        assert client.fallbacks == ["text-embedding-3-small"]
+        assert client.allow_unsafe_fallback is True
+        assert client.base_delay == 2.0
+        assert client.max_delay == 20.0
+
+
+class TestGetCompatibleFallbacks:
+    """Tests for get_compatible_fallbacks helper."""
+
+    def test_get_compatible_fallbacks_returns_list(self):
+        """Test get_compatible_fallbacks returns a list."""
+        client = Client()
+        fallbacks = client.get_compatible_fallbacks("voyage-3")
+        assert isinstance(fallbacks, list)
+
+    def test_get_compatible_fallbacks_excludes_same_model(self):
+        """Test get_compatible_fallbacks excludes the input model."""
+        client = Client()
+        fallbacks = client.get_compatible_fallbacks("voyage-3")
+        assert "voyageai:voyage-3" not in fallbacks
+
+
+class TestFallbackExhaustedError:
+    """Tests for FallbackExhaustedError."""
+
+    def test_fallback_exhausted_error_attributes(self):
+        """Test FallbackExhaustedError has correct attributes."""
+        error = FallbackExhaustedError(
+            primary_model="voyage-3",
+            fallbacks=["model-a", "model-b"],
+            errors={"voyage-3": RateLimitError("Rate limited")},
+            cycles_attempted=3,
+        )
+        assert error.primary_model == "voyage-3"
+        assert error.fallbacks == ["model-a", "model-b"]
+        assert "voyage-3" in error.errors
+        assert error.cycles_attempted == 3
+        assert "3 cycle(s)" in str(error)
+
+
+class TestConfigurationError:
+    """Tests for ConfigurationError."""
+
+    def test_configuration_error_message(self):
+        """Test ConfigurationError has correct message."""
+        error = ConfigurationError("Missing API key")
+        assert "Missing API key" in str(error)
+
+
+class TestEmbedResponseFallbackMetadata:
+    """Tests for EmbedResponse fallback metadata."""
+
+    def test_embed_response_default_fallback_fields(self):
+        """Test EmbedResponse has default fallback field values."""
+        response = EmbedResponse(
+            embeddings=[[0.1, 0.2, 0.3]],
+            model="voyage-3",
+            provider="voyageai",
+            dimensions=3,
+            usage=Usage(tokens=10, cost=0.000001),
+            latency_ms=100.0,
+            input_count=1,
+        )
+        assert response.fallback_used is False
+        assert response.requested_model is None
+        assert response.fallback_reason is None
+
+    def test_embed_response_with_fallback_metadata(self):
+        """Test EmbedResponse with fallback metadata."""
+        response = EmbedResponse(
+            embeddings=[[0.1, 0.2, 0.3]],
+            model="text-embedding-3-small",
+            provider="openai",
+            dimensions=3,
+            usage=Usage(tokens=10, cost=0.000001),
+            latency_ms=100.0,
+            input_count=1,
+            fallback_used=True,
+            requested_model="voyage-3",
+            fallback_reason="RateLimitError",
+        )
+        assert response.fallback_used is True
+        assert response.requested_model == "voyage-3"
+        assert response.fallback_reason == "RateLimitError"
+
+    def test_embed_response_repr_with_fallback(self):
+        """Test EmbedResponse repr includes fallback info when used."""
+        response = EmbedResponse(
+            embeddings=[[0.1, 0.2, 0.3]],
+            model="text-embedding-3-small",
+            provider="openai",
+            dimensions=3,
+            usage=Usage(tokens=10, cost=0.000001),
+            latency_ms=100.0,
+            input_count=1,
+            fallback_used=True,
+            requested_model="voyage-3",
+        )
+        repr_str = repr(response)
+        assert "fallback_used=True" in repr_str
+        assert "requested_model='voyage-3'" in repr_str


### PR DESCRIPTION
This pull request adds robust support for fallback models and error handling in the `catsu` package. It introduces new exception types for configuration and fallback failures, extends the `EmbedResponse` model to include fallback metadata, and adds comprehensive tests for fallback normalization, credential validation, dimension compatibility, error classification, and the new error types.

**Fallback and Error Handling Enhancements:**

* Added new exception classes `ConfigurationError` and `FallbackExhaustedError` to `catsu.utils.errors`, allowing the client to distinguish between configuration issues and cases where all fallback models have failed.
* Updated `src/catsu/__init__.py` to export the new exceptions, making them available at the package level.

**EmbedResponse Model Improvements:**

* Extended the `EmbedResponse` model with new fields: `requested_model`, `fallback_used`, and `fallback_reason`, providing detailed metadata when a fallback is triggered. The `__repr__` method now includes fallback information when relevant. [[1]](diffhunk://#diff-680475fc4ec1d2a4823e02818ea768155f8f36f962599c43a425018774cbc3b5R98-R100) [[2]](diffhunk://#diff-680475fc4ec1d2a4823e02818ea768155f8f36f962599c43a425018774cbc3b5R129-R141) [[3]](diffhunk://#diff-680475fc4ec1d2a4823e02818ea768155f8f36f962599c43a425018774cbc3b5L205-R229)

**Testing and Validation of Fallback Logic:**

* Added comprehensive tests in `tests/test_client.py` covering:
  - Fallback normalization logic for different input types.
  - Credential validation for primary and fallback models, raising `ConfigurationError` when API keys are missing.
  - Dimension compatibility filtering for fallback models.
  - Error classification to determine which errors trigger fallbacks.
  - Client configuration for fallback behavior.
  - The new `FallbackExhaustedError` and `ConfigurationError` classes.
  - `EmbedResponse` fallback metadata and representation. [[1]](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110R247-R509) [[2]](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110R4-R16)

**Minor Internal Improvements:**

* Updated type hints in `catsu.utils.errors` to include `List`, supporting the new exception classes.