### PR TITLE
Docs: Update README badges with improved styling and download stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 
 # 🌐 catsu 🐱
 
-[![PyPI version](https://img.shields.io/pypi/v/catsu.svg)](https://pypi.org/project/catsu/)
-[![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://pypi.org/project/catsu/)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Documentation](https://img.shields.io/badge/docs-latest-brightgreen.svg)](https://docs.catsu.dev)
-[![Stars](https://img.shields.io/github/stars/chonkie-inc/catsu?style=social)](https://github.com/chonkie-inc/catsu)
+[![PyPI version](https://img.shields.io/pypi/v/catsu.svg?style=flat&labelColor=black&color=orange)](https://pypi.org/project/catsu/)
+[![PyPI Downloads](https://static.pepy.tech/personalized-badge/catsu?period=total&units=international_system&left_color=black&right_color=orange&left_text=downloads)](https://pepy.tech/projects/catsu)
+[![Python](https://img.shields.io/badge/python-3.10+-orange.svg?style=flat&labelColor=black)](https://pypi.org/project/catsu/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-orange.svg?style=flat&labelColor=black)](https://opensource.org/licenses/Apache-2.0)
+[![Documentation](https://img.shields.io/badge/docs-latest-orange.svg?style=flat&labelColor=black)](https://docs.catsu.dev)
+[![Discord](https://img.shields.io/badge/discord-join-orange.svg?style=flat&labelColor=black&logo=discord&logoColor=white)](https://discord.gg/vH3SkRqmUz)
+[![Stars](https://img.shields.io/github/stars/chonkie-inc/catsu?style=flat&labelColor=black&color=orange)](https://github.com/chonkie-inc/catsu)
 
 _A unified, batteries-included client for embedding APIs that actually works._
 


### PR DESCRIPTION
This pull request updates the badge section at the top of the `README.md` file to improve its appearance and provide more information. The badges now use a consistent flat style with black and orange colors, add a downloads badge, and introduce a Discord community badge.

**README badge updates:**

* Updated all badges to use a flat style with black and orange color scheme for a more cohesive look.
* Added a total downloads badge using pepy.tech to display package popularity.
* Introduced a Discord badge to promote joining the project's community server.